### PR TITLE
fix: Make lambdas rely solely on the built in singleton functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ An example of creating each read-only custom endpoint follows.
 
 ### Use Current DatabaseCluster
 
-This is an example using the current `rds.DatabaseClusrer` definition method. Recommend this pattern.
+This is an example using the current `rds.DatabaseCluster` definition method. Recommend this pattern.
 
 ```ts
 import * as cdk from 'aws-cdk-lib';
@@ -154,9 +154,9 @@ new DatabaseClusterEndpoint(cluster, 'AnalyticalQueryEndpoint', {
 });
 ```
 
-### Use Legacy DatabaseClusrer
+### Use Legacy DatabaseCluster
 
-This is an example using the legacy `rds.DatabaseClusrer` definition method.
+This is an example using the legacy `rds.DatabaseCluster` definition method.
 
 ```ts
 import * as cdk from 'aws-cdk-lib';

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.0",
+  "version": "0.1.0-alpha.9",
   "jest": {
     "coverageProvider": "v8",
     "testMatch": [

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.0-alpha.9",
+  "version": "0.0.0",
   "jest": {
     "coverageProvider": "v8",
     "testMatch": [

--- a/src/lib/database-cluster-endpoint.ts
+++ b/src/lib/database-cluster-endpoint.ts
@@ -4,11 +4,9 @@ import {
   ArnFormat,
   CustomResource,
   Duration,
-  Lazy,
-  Names,
   Resource,
   Stack,
-  PhysicalName,
+  PhysicalName
 } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import {
@@ -148,14 +146,7 @@ export class DatabaseClusterEndpoint extends Resource {
   ) {
     super(scope, id, {
       physicalName:
-        props.endpointIdentifier ??
-        Lazy.string({
-          produce: () =>
-            Names.uniqueResourceName(this, {
-              allowedSpecialCharacters: '-',
-              maxLength: 63,
-            }).toLocaleLowerCase(),
-        }),
+        props.endpointIdentifier ?? PhysicalName.GENERATE_IF_NEEDED
     });
     const endpointType = props.endpointType ?? DatabaseClusterEndpointType.ANY;
     const excludedMembers =
@@ -174,7 +165,7 @@ export class DatabaseClusterEndpoint extends Resource {
         architecture: Architecture.ARM_64,
         timeout: Duration.minutes(15),
         uuid: '7ebee0fa-b9cc-4ef6-8ded-0294ad649bf7',
-        functionName: PhysicalName.GENERATE_IF_NEEDED,
+        functionName: 'ResourceManageFunction-7ebee0fa-b9cc-4ef6-8ded-0294ad649bf7',
       });
     }
     onEventHandler.addToRolePolicy(
@@ -215,7 +206,7 @@ export class DatabaseClusterEndpoint extends Resource {
         architecture: Architecture.ARM_64,
         timeout: Duration.minutes(15),
         uuid: 'c061108a-4752-4df0-8bbb-08c172a86d19',
-        functionName: PhysicalName.GENERATE_IF_NEEDED,
+        functionName: 'ResourceWaitFunction-c061108a-4752-4df0-8bbb-08c172a86d19',
       });
     }
     isCompleteHandler.addToRolePolicy(
@@ -250,6 +241,7 @@ export class DatabaseClusterEndpoint extends Resource {
         onEventHandler,
         isCompleteHandler,
         queryInterval: Duration.seconds(30),
+				providerFunctionName: PhysicalName.GENERATE_IF_NEEDED,
       }
     );
     this.resource = new CustomResource(this, 'Resource', {

--- a/src/lib/database-cluster-endpoint.ts
+++ b/src/lib/database-cluster-endpoint.ts
@@ -8,6 +8,7 @@ import {
   Names,
   Resource,
   Stack,
+  PhysicalName,
 } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import {
@@ -173,6 +174,7 @@ export class DatabaseClusterEndpoint extends Resource {
         architecture: Architecture.ARM_64,
         timeout: Duration.minutes(15),
         uuid: '7ebee0fa-b9cc-4ef6-8ded-0294ad649bf7',
+        functionName: PhysicalName.GENERATE_IF_NEEDED,
       });
     }
     onEventHandler.addToRolePolicy(
@@ -213,6 +215,7 @@ export class DatabaseClusterEndpoint extends Resource {
         architecture: Architecture.ARM_64,
         timeout: Duration.minutes(15),
         uuid: 'c061108a-4752-4df0-8bbb-08c172a86d19',
+        functionName: PhysicalName.GENERATE_IF_NEEDED,
       });
     }
     isCompleteHandler.addToRolePolicy(

--- a/src/lib/database-cluster-endpoint.ts
+++ b/src/lib/database-cluster-endpoint.ts
@@ -177,6 +177,7 @@ export class DatabaseClusterEndpoint extends Resource {
         architecture: Architecture.ARM_64,
         timeout: Duration.minutes(15),
         uuid: '7ebee0fa-b9cc-4ef6-8ded-0294ad649bf7',
+        functionName: PhysicalName.GENERATE_IF_NEEDED,
       }
     );
 
@@ -222,6 +223,7 @@ export class DatabaseClusterEndpoint extends Resource {
         architecture: Architecture.ARM_64,
         timeout: Duration.minutes(15),
         uuid: 'c061108a-4752-4df0-8bbb-08c172a86d19',
+        functionName: PhysicalName.GENERATE_IF_NEEDED,
       }
     );
 

--- a/src/lib/database-cluster-endpoint.ts
+++ b/src/lib/database-cluster-endpoint.ts
@@ -8,7 +8,7 @@ import {
   Stack,
   PhysicalName,
   Names,
-  Lazy
+  Lazy,
 } from 'aws-cdk-lib';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import {
@@ -167,14 +167,18 @@ export class DatabaseClusterEndpoint extends Resource {
 
     const stack = Stack.of(this);
 
-    const onEventHandler = new SingletonFunction(this, 'DBClusterEndpointEventHandler', {
-      runtime: Runtime.NODEJS_LATEST,
-      code: Code.fromAsset(join(__dirname, 'wait-for-action-finish')),
-      handler: 'index.onEvent',
-      architecture: Architecture.ARM_64,
-      timeout: Duration.minutes(15),
-      uuid: '7ebee0fa-b9cc-4ef6-8ded-0294ad649bf7',
-    });
+    const onEventHandler = new SingletonFunction(
+      this,
+      'DBClusterEndpointEventHandler',
+      {
+        runtime: Runtime.NODEJS_LATEST,
+        code: Code.fromAsset(join(__dirname, 'wait-for-action-finish')),
+        handler: 'index.onEvent',
+        architecture: Architecture.ARM_64,
+        timeout: Duration.minutes(15),
+        uuid: '7ebee0fa-b9cc-4ef6-8ded-0294ad649bf7',
+      }
+    );
 
     onEventHandler.addToRolePolicy(
       new PolicyStatement({
@@ -208,14 +212,18 @@ export class DatabaseClusterEndpoint extends Resource {
     );
 
     // Get or create completion handler at stack level
-    const isCompleteHandler = new SingletonFunction(this, 'DBClusterEndpointCompletionHandler', {
-      runtime: Runtime.NODEJS_LATEST,
-      code: Code.fromAsset(join(__dirname, 'wait-for-action-finish')),
-      handler: 'index.isComplete',
-      architecture: Architecture.ARM_64,
-      timeout: Duration.minutes(15),
-      uuid: 'c061108a-4752-4df0-8bbb-08c172a86d19',
-    });
+    const isCompleteHandler = new SingletonFunction(
+      this,
+      'DBClusterEndpointCompletionHandler',
+      {
+        runtime: Runtime.NODEJS_LATEST,
+        code: Code.fromAsset(join(__dirname, 'wait-for-action-finish')),
+        handler: 'index.isComplete',
+        architecture: Architecture.ARM_64,
+        timeout: Duration.minutes(15),
+        uuid: 'c061108a-4752-4df0-8bbb-08c172a86d19',
+      }
+    );
 
     isCompleteHandler.addToRolePolicy(
       new PolicyStatement({
@@ -250,7 +258,7 @@ export class DatabaseClusterEndpoint extends Resource {
         onEventHandler,
         isCompleteHandler,
         queryInterval: Duration.seconds(30),
-				providerFunctionName: PhysicalName.GENERATE_IF_NEEDED,
+        providerFunctionName: PhysicalName.GENERATE_IF_NEEDED,
       }
     );
     this.resource = new CustomResource(this, 'Resource', {


### PR DESCRIPTION
Fixes #

Using this package in a CDK Pipeline causes it to error out with the following error

ValidationError: Resolution error: Resolution error: Resolution error: Resolution error: Cannot use resource '[path]/SingletonLambdac061108a47524df08bbb08c172a86d19' in a cross-environment fashion, the resource's physical name must be explicit set or use `PhysicalName.GENERATE_IF_NEEDED`

This PR should adress that

Also fixed typo in readme

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
