### PR TITLE
fix: exempt dependency upgrade PRs from contributor statement lint

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -44,7 +44,7 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
       EXPECTED: _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
       HELP: Contributor statement missing from PR description. Please include the following text in the PR description
-    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !(contains(github.event.pull_request.labels.*.name, 'auto-upgrade'))
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -80,6 +80,7 @@ jobs:
             *Automatically created by projen via the "upgrade-main" workflow*
           branch: github-actions/upgrade-main
           title: "chore(deps): upgrade dependencies"
+          labels: auto-upgrade
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -53,6 +53,14 @@ const project = new awscdk.AwsCdkConstructLibrary({
       },
       contributorStatement:
         '_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_',
+      contributorStatementOptions: {
+        exemptLabels: ['auto-upgrade'],
+      },
+    },
+  },
+  depsUpgradeOptions: {
+    workflowOptions: {
+      labels: ['auto-upgrade'],
     },
   },
   experimentalIntegRunner: true,


### PR DESCRIPTION
The upgrade-main workflow creates PRs using a PAT, so the PR author is the token owner rather 
than github-actions[bot]. Since the auto-generated PR body doesn't include the contributor 
statement, the PR lint check fails.

This fix adds an auto-upgrade label to dependency upgrade PRs and exempts PRs with that label 
from the contributor statement check.

Fixes #

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
